### PR TITLE
added force_first_load()

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Pantheon Sessions for WordPress
-Version: 0.1-alpha
+Version: 0.2-Alpha
 Description: Offload PHP sessions to your database for multi-server compatibility.
 Author: Pantheon
 Author URI: https://www.getpantheon.com/
@@ -36,7 +36,6 @@ class Pantheon_Sessions {
 			$this->set_ini_values();
 			$this->initialize_session_override();
 		}
-
 	}
 
 	/**
@@ -184,6 +183,27 @@ class Pantheon_Sessions {
 
 	}
 
+
+	/**
+	 * Force the plugin to be the first loaded
+	 *
+	 */
+	static public function force_first_load()
+	{
+
+		$path = str_replace( WP_PLUGIN_DIR . '/', '', __FILE__ );
+		if ( $plugins = get_option( 'active_plugins' ) ) {
+			if ( $key = array_search( $path, $plugins ) ) {
+				array_splice( $plugins, $key, 1 );
+				array_unshift( $plugins, $path );
+				update_option( 'active_plugins', $plugins );
+			}
+		}
+
+		return;
+	}
+
+
 	/**
 	 * Get a randomized key
 	 *
@@ -203,4 +223,7 @@ class Pantheon_Sessions {
 function Pantheon_Sessions() {
 	return Pantheon_Sessions::get_instance();
 }
+
+add_action( 'activated_plugin', 'Pantheon_Sessions::force_first_load');
+
 Pantheon_Sessions();


### PR DESCRIPTION
This may be deemed an edge case. I don't think it is, but I understand if you think it is. :) 

This weekend I ran into an interesting situation.

I wanted to play with a new plugin, so I : 
Created a Pantheon Sandbox.
Added the plugin into WordPress
Activated it

In my error logs I noticed that it was failing because it was trying to start sessions.

So I added and activated wp-native-php-sessions

Then I attempted to re-activate the original plugin. It was still throwing the same error.

After a debugging session, I came to the conclusion that WordPress - absent of any other direction, will load plugins in the order that they are installed. Since my other plugin was installed first, it was always going to be loaded before wp-native-php-sessions.

So a bit of googling and I found a solution. The code I added was blatantly ripped off from a tutorial. I read 3, saw the same code in all 3, so I figured it would work. It does.

I added a hook to fire the new code upon installation. 

It just seemed to be easier to put it in as a static method in the class than to create a function that instantiates the object just to fire the method. Feel free to re-arrange if you accept this PR. 

If you want to test, follow these steps. (Takes about 10 minutes)

1. Create a Pantehon WordPress sandbox
1. Complete the WordPress install
1. Using FTP, place this code in a file called CalsTest.php in plugins. https://gist.github.com/calevans/c58ec7ec07f71ec15cac
1. Activate Cal’s Test
1. It should display a WordPress error and then not activate the plugin
1. Install Pantheon session handler
1. Activate Pantheon Session Handler
1. Activate CalsTest
1. BOOM goes the dynamite (Your site is now unstable)
1.  FTP in and Rename CalsTest.php CalsTest.php.old
1. Refresh the plugins page. Without the offending plugin, it will work.
1. Deactivate Pantheon Sessions
1. Add my patch to Pantheon Sessions
1. Refresh the plugins page to make sure the version number changes
1. Activate Pantheon Sessions
1. Rename CalsTest.php.old CalsTest.php
1. Activate CalsTest.php
1. Nothing happens. Exactly! :)

