### PR TITLE
Fix table registration for pantheon_sessions

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -162,7 +162,7 @@ class Pantheon_Sessions {
 
 		$table_name = "{$table_prefix}pantheon_sessions";
 		$wpdb->pantheon_sessions = $table_name;
-		$wpdb->tables[] = $table_name;
+		$wpdb->tables[] = 'pantheon_sessions';
 
 		if ( get_option( 'pantheon_session_version' ) ) {
 			return;


### PR DESCRIPTION
Calling `$wpdb->tables` returns the table name, *without the prefix*.  This means that when you add a table with   `$wpdb->tables[] = foo`, you need to be careful not to pass a table name with the prefix already attached.  Otherwise, code that uses `$wpdb->tables` will end up adding it's own prefix, and you will end up with something like "wp_wp_foo"

You can actually see this in action by doing something like:

`wp-cli eval 'global $wpdb; print_r($wpdb->tables);'`

which shows:

````
Array
(
    [0] => posts
    [1] => comments
    [2] => links
    [3] => options
    [4] => postmeta
    [5] => terms
    [6] => term_taxonomy
    [7] => term_relationships
    [8] => commentmeta
    [9] => wp_pantheon_sessions
)
````

where the pantheon_sessions table is the only one with the prefix applied.

I'm not sure if this affects anything in practice.  I noticed when cribbing your table registration code to use somewhere else.