### PR TITLE
Move session_id() call later into the process for better compatibility.

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -127,31 +127,8 @@ class Pantheon_Sessions {
 	 * Largely adopted from Drupal 7's implementation
 	 */
 	private function initialize_session_override() {
-
 		session_set_save_handler( '_pantheon_session_open', '_pantheon_session_close', '_pantheon_session_read', '_pantheon_session_write', '_pantheon_session_destroy', '_pantheon_session_garbage_collection' );
-
 		require_once dirname( __FILE__ ) . '/inc/class-session.php';
-
-		// We use !empty() in the following check to ensure that blank session IDs are not valid.
-		if ( ! empty( $_COOKIE[ session_name() ] ) || ( is_ssl() && ! empty( $_COOKIE[ substr(session_name(), 1) ] ) ) ) {
-			// If a session cookie exists, initialize the session. Otherwise the
-			// session is only started on demand in _pantheon_session_write(), making
-			// anonymous users not use a session cookie unless something is stored in
-			// $_SESSION. This allows HTTP proxies to cache anonymous pageviews.
-			if ( get_current_user_id() || ! empty( $_SESSION ) ) {
-				nocache_headers();
-			}
-		} else {
-			// Set a session identifier for this request. This is necessary because
-			// we lazily start sessions at the end of this request
-			session_id( $this->get_random_key() );
-			if ( is_ssl() ) {
-				$insecure_session_name = substr( session_name(), 1 );
-				$session_id = $this->get_random_key();
-				$_COOKIE[ $insecure_session_name ] = $session_id;
-			}
-		}
-
 	}
 
 	/**
@@ -201,18 +178,6 @@ class Pantheon_Sessions {
 		}
 
 		return;
-	}
-
-
-	/**
-	 * Get a randomized key
-	 *
-	 * @return string
-	 */
-	public function get_random_key() {
-		require_once( ABSPATH . 'wp-includes/class-phpass.php');
-		$hasher = new PasswordHash( 8, false );
-		return md5( $hasher->get_random_bytes( 32 ) );
 	}
 
 }


### PR DESCRIPTION
This addressess some issues we saw with EDD and Give plugins (e.g. #10).

Would love some more people to field test this before we roll in to release. 