### PR TITLE
Add return to session_write_close callback function

### DIFF
--- a/callbacks.php
+++ b/callbacks.php
@@ -102,7 +102,8 @@ function _pantheon_session_write( $sid, $value ) {
 	}
 
 	$session->set_data( $value );
-
+	
+	return true;
 }
 
 /**


### PR DESCRIPTION
Warning: session_write_close(): Session callback expects true/false return value.
Testing in php-7.0.3