### PR TITLE
Guarantee session hash uniqueness

### DIFF
--- a/callbacks.php
+++ b/callbacks.php
@@ -26,15 +26,15 @@ function _pantheon_session_open() {
 		// we lazily start sessions at the end of this request
 		require_once( ABSPATH . 'wp-includes/class-phpass.php');
 		$hasher = new PasswordHash( 8, false );
-    do {
-      $sid = md5( $hasher->get_random_bytes( 32 ) );
-    } while( \Pantheon_Sessions\Session::sid_exists( $sid ) );
+		do {
+			$sid = md5( $hasher->get_random_bytes( 32 ) );
+		} while( \Pantheon_Sessions\Session::sid_exists( $sid ) );
 		session_id( $sid );
 		if ( is_ssl() ) {
 			$insecure_session_name = substr( session_name(), 1 );
-      do {
-        $insecure_session_id = md5( $hasher->get_random_bytes( 32 ) );
-      } while( \Pantheon_Sessions\Session::sid_exists( $insecure_session_id, true ) );
+			do {
+				$insecure_session_id = md5( $hasher->get_random_bytes( 32 ) );
+			} while( \Pantheon_Sessions\Session::sid_exists( $insecure_session_id, true ) );
 			$_COOKIE[ $insecure_session_name ] = $insecure_session_id;
 		}
 	}

--- a/callbacks.php
+++ b/callbacks.php
@@ -26,10 +26,15 @@ function _pantheon_session_open() {
 		// we lazily start sessions at the end of this request
 		require_once( ABSPATH . 'wp-includes/class-phpass.php');
 		$hasher = new PasswordHash( 8, false );
-		session_id( md5( $hasher->get_random_bytes( 32 ) ) );
+    do {
+      $sid = md5( $hasher->get_random_bytes( 32 ) );
+    } while( \Pantheon_Sessions\Session::sid_exists( $sid ) );
+		session_id( $sid );
 		if ( is_ssl() ) {
 			$insecure_session_name = substr( session_name(), 1 );
-			$insecure_session_id = md5( $hasher->get_random_bytes( 32 ) );
+      do {
+        $insecure_session_id = md5( $hasher->get_random_bytes( 32 ) );
+      } while( \Pantheon_Sessions\Session::sid_exists( $insecure_session_id, true ) );
 			$_COOKIE[ $insecure_session_name ] = $insecure_session_id;
 		}
 	}

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -57,7 +57,7 @@ class Session {
 	public static function sid_exists( $sid, $secure = false ) {
 		global $wpdb;
 		$column_name = 'session_id';
-		if($secure) {
+		if( $secure ) {
 			$column_name = 'secure_session_id';
 		}
 		$session_row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->pantheon_sessions} WHERE {$column_name}=%s", $sid ) );

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -115,21 +115,21 @@ class Session {
 	 * Determines if a session ID exists in the database.
 	 *
 	 * @param string $sid
-   * @param bool $secure
+	 * @param bool $secure
 	 * @return true|false
 	 */
-  public function sid_exists( $sid, $secure = false ) {
+	public function sid_exists( $sid, $secure = false ) {
 		global $wpdb;
-    $column_name = 'session_id';
-    if($secure) {
-      $column_name = 'secure_session_id';
-    }
+		$column_name = 'session_id';
+		if($secure) {
+			$column_name = 'secure_session_id';
+		}
 		$session_row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->pantheon_sessions} WHERE {$column_name}=%s", $sid ) );
 		if ( ! $session_row ) {
 			return false;
 		}
-    return true;
-  }
+		return true;
+	}
 
 	/**
 	 * Delete session cookies

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -110,6 +110,26 @@ class Session {
 		$this->delete_cookies();
 
 	}
+  
+	/**
+	 * Determines if a session ID exists in the database.
+	 *
+	 * @param string $sid
+   * @param bool $secure
+	 * @return true|false
+	 */
+  public function sid_exists( $sid, $secure = false ) {
+		global $wpdb;
+    $column_name = 'session_id';
+    if($secure) {
+      $column_name = 'secure_session_id';
+    }
+		$session_row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->pantheon_sessions} WHERE {$column_name}=%s", $sid ) );
+		if ( ! $session_row ) {
+			return false;
+		}
+    return true;
+  }
 
 	/**
 	 * Delete session cookies

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -47,6 +47,26 @@ class Session {
 		return self::get_by_sid( $sid );
 	}
 
+	/**
+	 * Determines if a session ID exists in the database.
+	 *
+	 * @param string $sid
+	 * @param bool $secure
+	 * @return true|false
+	 */
+	public static function sid_exists( $sid, $secure = false ) {
+		global $wpdb;
+		$column_name = 'session_id';
+		if($secure) {
+			$column_name = 'secure_session_id';
+		}
+		$session_row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->pantheon_sessions} WHERE {$column_name}=%s", $sid ) );
+		if ( ! $session_row ) {
+			return false;
+		}
+		return true;
+	}
+
 	private function __construct( $sid, $data ) {
 		$this->sid = $sid;
 		$this->data = $data;
@@ -111,26 +131,6 @@ class Session {
 
 	}
   
-	/**
-	 * Determines if a session ID exists in the database.
-	 *
-	 * @param string $sid
-	 * @param bool $secure
-	 * @return true|false
-	 */
-	public function sid_exists( $sid, $secure = false ) {
-		global $wpdb;
-		$column_name = 'session_id';
-		if($secure) {
-			$column_name = 'secure_session_id';
-		}
-		$session_row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->pantheon_sessions} WHERE {$column_name}=%s", $sid ) );
-		if ( ! $session_row ) {
-			return false;
-		}
-		return true;
-	}
-
 	/**
 	 * Delete session cookies
 	 */

--- a/tests/test-sessions.php
+++ b/tests/test-sessions.php
@@ -29,6 +29,18 @@ class Test_Sessions extends WP_UnitTestCase {
 		return $session;
 	}
 
+	public function test_session_exists() {
+		$_SESSION['foo'] = 'bar';
+		session_commit();
+		$session_id = session_id();
+		$exists = \Pantheon_Sessions\Session::sid_exists( $session_id );
+		$this->assertTrue( $exists );
+		$session = \Pantheon_Sessions\Session::get_by_sid( $session_id );
+		$session->destroy();
+		$exists = \Pantheon_Sessions\Session::sid_exists( $session_id );
+		$this->assertFalse( $exists );
+	}
+
 	/**
 	 * @depends test_session_write_read
 	 */


### PR DESCRIPTION
For a shopping cart, we need to ensure that all session hash keys are indeed unique. This patch will validate any new session keys against the database for uniqueness.  There are still some potential collision paths, but this is a good start.

The biggest chance is that two identical hashes are created at the same time, both clear the database check, and then both attempt to write to the database.  This is still a much smaller chance than a basic hash collision.