### PR TITLE
Pinning Terminus on 0.12.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,7 +29,7 @@ dependencies:
         echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
         exit 0
       fi
-      composer global require pantheon-systems/terminus
+      composer global require pantheon-systems/terminus "<0.13.0"
       composer install
       terminus auth login --machine-token=$TERMINUS_TOKEN
 


### PR DESCRIPTION
The master branch is failing tests with Terminus 0.13.0 and 0.13.1