### PR TITLE
Terminus 0.13.3

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ dependencies:
         echo "TERMINUS_TOKEN environment variables missing; assuming unauthenticated build"
         exit 0
       fi
-      composer global require pantheon-systems/terminus "<0.13.0"
+      composer global require pantheon-systems/terminus ">=0.13.3"
       composer install
       terminus auth login --machine-token=$TERMINUS_TOKEN
 


### PR DESCRIPTION
Previous versions of Terminus (`0.13.0`, `0.13.1`) had errors that broke the scripts in this repo so we set the version to be lower than `0.13.0`. Those bugs have since been fixed.