### PR TITLE
Type cast user id as integer, not boolean

### DIFF
--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -87,7 +87,7 @@ class Session {
 		}
 
 		$wpdb->update( $wpdb->pantheon_sessions, array(
-			'user_id'         => (bool)get_current_user_id(),
+			'user_id'         => (int) get_current_user_id(),
 			'datetime'        => date( 'Y-m-d H:i:s' ),
 			'ip_address'      => preg_replace( '/[^0-9a-fA-F:., ]/', '', $_SERVER['REMOTE_ADDR'] ),
 			'data'            => maybe_serialize( $data ),


### PR DESCRIPTION
The user id is currently cast as a boolean, which returns 1 for any logged-in user. Casting as an integer fixes this and returns 0 for logged-out users.