### PR TITLE
Ensure session is closed before `$wpdb` destructs itself

### DIFF
--- a/callbacks.php
+++ b/callbacks.php
@@ -59,12 +59,6 @@ function _pantheon_session_open() {
  */
 function _pantheon_session_read( $sid ) {
 
-	// Write and Close handlers are called after destructing objects
-	// since PHP 5.0.5.
-	// Thus destructors can use sessions but session handler can't use objects.
-	// So we are moving session closure before destructing objects.
-	register_shutdown_function( 'session_write_close' );
-
 	// Handle the case of first time visitors and clients that don't store
 	// cookies (eg. web crawlers).
 	$insecure_session_name = substr( session_name(), 1 );

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -130,6 +130,8 @@ class Pantheon_Sessions {
 	 */
 	private function initialize_session_override() {
 		session_set_save_handler( '_pantheon_session_open', '_pantheon_session_close', '_pantheon_session_read', '_pantheon_session_write', '_pantheon_session_destroy', '_pantheon_session_garbage_collection' );
+		// Close the session before $wpdb destructs itself
+		add_action( 'shutdown', 'session_write_close', 999 );
 		require_once dirname( __FILE__ ) . '/inc/class-session.php';
 	}
 


### PR DESCRIPTION
`$wpdb` destructs itself on PHP's shutdown hook, which means it's not
available to `session_write_close()` if `session_write_close()` was
registered for shutdown after `$wpdb` is instantiated.

Instead, we can use WordPress' internal `shutdown` action, which fires
just a wee bit before.

Fixes #49