### PR TITLE
Warning: session_write_close

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -131,7 +131,7 @@ class Pantheon_Sessions {
 	private function initialize_session_override() {
 		session_set_save_handler( '_pantheon_session_open', '_pantheon_session_close', '_pantheon_session_read', '_pantheon_session_write', '_pantheon_session_destroy', '_pantheon_session_garbage_collection' );
 		// Close the session before $wpdb destructs itself
-		add_action( 'shutdown', 'session_write_close', 999 );
+		add_action( 'shutdown', 'session_write_close', 999, 0 );
 		require_once dirname( __FILE__ ) . '/inc/class-session.php';
 	}
 


### PR DESCRIPTION
Fixes Warning: session_write_close() expects exactly 0 parameters, 1 given.
Default accepted args value is 1 for hooks, setting it to 0 solved the problem.

Originally #65