### PR TITLE
Restore session instantiation when WP-CLI is executing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ However, if you intend to scale your application, local tempfiles are a dangerou
 
 ## Changelog ##
 
+### 0.6.6 (March 8th, 2018) ###
+* Restores session instantiation when WP-CLI is executing, because not doing so causes other problems.
+
 ### 0.6.5 (February 6th, 2018) ###
 * Disables session instantiation when `defined( 'WP_CLI' ) && WP_CLI` because sessions don't work on CLI.
 

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Native PHP Sessions for WordPress
- * Version: 0.6.5
+ * Version: 0.6.6
  * Description: Offload PHP's native sessions to your database for multi-server compatibility.
  * Author: Pantheon
  * Author URI: https://www.pantheon.io/
@@ -12,7 +12,7 @@
 
 use Pantheon_Sessions\Session;
 
-define( 'PANTHEON_SESSIONS_VERSION', '0.6.5' );
+define( 'PANTHEON_SESSIONS_VERSION', '0.6.6' );
 
 class Pantheon_Sessions {
 

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -37,10 +37,6 @@ class Pantheon_Sessions {
 
 		if ( PANTHEON_SESSIONS_ENABLED ) {
 
-			if ( defined( 'WP_CLI' ) && WP_CLI ) {
-				return;
-			}
-
 			$this->setup_database();
 			$this->set_ini_values();
 			$this->initialize_session_override();

--- a/readme.txt
+++ b/readme.txt
@@ -66,6 +66,9 @@ If you see an error like "Fatal error: session_start(): Failed to initialize sto
 
 == Changelog ==
 
+= 0.6.6 (March 8th, 2018) =
+* Restores session instantiation when WP-CLI is executing, because not doing so causes other problems.
+
 = 0.6.5 (February 6th, 2018) =
 * Disables session instantiation when `defined( 'WP_CLI' ) && WP_CLI` because sessions don't work on CLI.
 


### PR DESCRIPTION
See https://github.com/pantheon-systems/wp-native-php-sessions/issues/87#issuecomment-371292451