### PR TITLE
destroy() should return with a value

### DIFF
--- a/callbacks.php
+++ b/callbacks.php
@@ -123,6 +123,7 @@ function _pantheon_session_destroy( $sid ) {
 
 	$session->destroy();
 
+	return true;
 }
 
 /**


### PR DESCRIPTION
From PHP [session_set_save_handler() doc](https://secure.php.net/manual/en/function.session-set-save-handler.php) under `destroy($sessionId)`
> Return value should be TRUE for success, FALSE for failure.