### PR TITLE
Various test updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,24 +38,19 @@ before_script:
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - composer install
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-      composer global require "phpunit/phpunit=5.7.*"
-    fi
-  - |
-    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
-      composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
     fi
 
 script:
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
-      phpunit
-      WP_MULTISITE=1 phpunit
+      composer test
+      WP_MULTISITE=1 composer test
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
-      phpcs
+      composer lint
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,14 @@ branches:
 
 matrix:
   include:
+    - php: 7.3
+      env: WP_VERSION=latest
     - php: 7.2
       env: WP_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=trunk
     - php: 7.1
       env: WP_VERSION=latest
-    - php: 7.0
-      env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=4.7
-    - php: 5.6
-      env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=trunk
 
 before_script:
     - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WordPress Native PHP Sessions #
-**Contributors:** getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber  
+**Contributors:** getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andrew.taylor  
 **Tags:** comments, sessions  
 **Requires at least:** 4.7  
 **Tested up to:** 5.2  

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,15 @@
     ],
     "minimum-stability": "dev",
     "require-dev": {
-        "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master"
+        "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master",
+        "wp-coding-standards/wpcs": "dev-master",
+        "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
+        "phpunit/phpunit": "^7"
+    },
+    "scripts": {
+        "lint": "@phpcs",
+        "phpcs": "vendor/bin/phpcs",
+        "phpunit": "vendor/bin/phpunit",
+        "test": "@phpunit"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="main">
 			<directory prefix="test-" suffix=".php">./tests/phpunit/</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
* Switches PHPUnit to a dev dependency.
* Tests against PHP 7.3; drops testing support for PHP 5.6 (fixes #109).
* Renames `phpunit.xml` to `phpunit.xml.dist`.