### PR TITLE
Fix handling of 'X-Forwarded-For' header in `get_client_ip_server()`

### DIFF
--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -205,11 +205,19 @@ class Session {
 			'REMOTE_ADDR',
 		];
 
+		$ip_filter_flags = apply_filters( 'pantheon_client_ip_filter_flags', FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
+
 		foreach ( $keys as $key ) {
 			if ( array_key_exists( $key, $_SERVER )
 				&& $_SERVER[ $key ]
 			) {
-				$ip_address = $_SERVER[ $key ];
+				$_ip_address = $_SERVER[ $key ];
+
+				if ( false === filter_var( $_ip_address, FILTER_VALIDATE_IP, $ip_filter_flags ) ) {
+					return;
+				}
+
+				$ip_address = $_ip_address;
 				$ip_source  = $key;
 				break;
 			}

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -205,7 +205,7 @@ class Session {
 			'REMOTE_ADDR',
 		];
 
-		$ip_filter_flags = apply_filters( 'pantheon_client_ip_filter_flags', FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE );
+		$ip_filter_flags = apply_filters( 'pantheon_client_ip_filter_flags', FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE );
 
 		foreach ( $keys as $key ) {
 			if ( array_key_exists( $key, $_SERVER )

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -193,7 +193,7 @@ class Session {
 	 */
 	public static function get_client_ip_server() {
 		// Set default.
-		$ipaddress = '127.0.0.1';
+		$ip_address = '127.0.0.1';
 
 		$keys = [
 			'HTTP_CLIENT_IP',
@@ -208,14 +208,14 @@ class Session {
 			if ( array_key_exists( $key, $_SERVER )
 				&& $_SERVER[ $key ]
 			) {
-				$ipaddress = $_SERVER[ $key ];
+				$ip_address = $_SERVER[ $key ];
 				break;
 			}
 		}
 
 		return apply_filters(
 			'pantheon_client_ip',
-			preg_replace( '/[^0-9a-fA-F:., ]/', '', $ipaddress )
+			preg_replace( '/[^0-9a-fA-F:., ]/', '', $ip_address )
 		);
 	}
 

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -193,7 +193,7 @@ class Session {
 	 */
 	public static function get_client_ip_server() {
 		// Set default.
-		$ip_address = '127.0.0.1';
+		$ip_address = apply_filters( 'pantheon_client_ip_default', '127.0.0.1' );
 		$ip_source  = null;
 
 		$keys = [
@@ -212,6 +212,10 @@ class Session {
 				&& $_SERVER[ $key ]
 			) {
 				$_ip_address = $_SERVER[ $key ];
+
+				if ( false !== strpos( $_ip_address, ',' ) ) {
+					$_ip_address = trim( strstr( $_ip_address, ',', true ) );
+				}
 
 				if ( false === filter_var( $_ip_address, FILTER_VALIDATE_IP, $ip_filter_flags ) ) {
 					return;

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -194,6 +194,7 @@ class Session {
 	public static function get_client_ip_server() {
 		// Set default.
 		$ip_address = '127.0.0.1';
+		$ip_source  = null;
 
 		$keys = [
 			'HTTP_CLIENT_IP',
@@ -209,13 +210,15 @@ class Session {
 				&& $_SERVER[ $key ]
 			) {
 				$ip_address = $_SERVER[ $key ];
+				$ip_source  = $key;
 				break;
 			}
 		}
 
 		return apply_filters(
 			'pantheon_client_ip',
-			preg_replace( '/[^0-9a-fA-F:., ]/', '', $ip_address )
+			preg_replace( '/[^0-9a-fA-F:., ]/', '', $ip_address ),
+			$ip_source
 		);
 	}
 

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -218,7 +218,7 @@ class Session {
 				}
 
 				if ( false === filter_var( $_ip_address, FILTER_VALIDATE_IP, $ip_filter_flags ) ) {
-					return;
+					continue;
 				}
 
 				$ip_address = $_ip_address;

--- a/inc/class-session.php
+++ b/inc/class-session.php
@@ -193,7 +193,7 @@ class Session {
 	 */
 	public static function get_client_ip_server() {
 		// Set default.
-		$ip_address = apply_filters( 'pantheon_client_ip_default', '127.0.0.1' );
+		$ip_address = apply_filters( 'pantheon_sessions_client_ip_default', '127.0.0.1' );
 		$ip_source  = null;
 
 		$keys = [
@@ -205,7 +205,7 @@ class Session {
 			'REMOTE_ADDR',
 		];
 
-		$ip_filter_flags = apply_filters( 'pantheon_client_ip_filter_flags', FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE );
+		$ip_filter_flags = apply_filters( 'pantheon_sessions_client_ip_filter_flags', FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 | FILTER_FLAG_NO_RES_RANGE );
 
 		foreach ( $keys as $key ) {
 			if ( array_key_exists( $key, $_SERVER )
@@ -228,7 +228,7 @@ class Session {
 		}
 
 		return apply_filters(
-			'pantheon_client_ip',
+			'pantheon_sessions_client_ip',
 			preg_replace( '/[^0-9a-fA-F:., ]/', '', $ip_address ),
 			$ip_source
 		);

--- a/tests/phpunit/test-sessions.php
+++ b/tests/phpunit/test-sessions.php
@@ -162,6 +162,13 @@ class Test_Sessions extends WP_UnitTestCase {
 		$_SERVER['HTTP_CLIENT_IP']   = '192.168.1.2';
 		$_SERVER['HTTP_X_FORWARDED'] = '192.168.1.3';
 		$this->assertEquals( '192.168.1.2', Session::get_client_ip_server() );
+		// 'HTTP_X_FORWARDED_FOR' should be in an comma seperated format. Return first value.
+		$_SERVER = [
+			'HTTP_CLIENT_IP'   => null,
+			'HTTP_X_FORWARDED' => null,
+		] + $_SERVER;
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '192.168.1.4, 5.6.7.8, 9.10.11.12';
+		$this->assertEquals( '192.168.1.4', Session::get_client_ip_server() );
 	}
 
 	/**

--- a/tests/phpunit/test-sessions.php
+++ b/tests/phpunit/test-sessions.php
@@ -162,11 +162,12 @@ class Test_Sessions extends WP_UnitTestCase {
 		$_SERVER['HTTP_CLIENT_IP']   = '192.168.1.2';
 		$_SERVER['HTTP_X_FORWARDED'] = '192.168.1.3';
 		$this->assertEquals( '192.168.1.2', Session::get_client_ip_server() );
-		// 'HTTP_X_FORWARDED_FOR' should be in an comma seperated format. Return first value.
+		// Reset $_SERVER.
 		$_SERVER = [
 			'HTTP_CLIENT_IP'   => null,
 			'HTTP_X_FORWARDED' => null,
 		] + $_SERVER;
+		// 'HTTP_X_FORWARDED_FOR' should be in an comma seperated format. Return first value.
 		$_SERVER['HTTP_X_FORWARDED_FOR'] = '192.168.1.4, 5.6.7.8, 9.10.11.12';
 		$this->assertEquals( '192.168.1.4', Session::get_client_ip_server() );
 	}


### PR DESCRIPTION
> The `X-Forwarded-For` HTTP Header could / should be in a comma separated format.

Fixes #124
Originally #125