### PR TITLE
don't ini_set() if session is active

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -100,7 +100,7 @@ class Pantheon_Sessions {
 	 */
 	private function set_ini_values() {
 
-		if ( headers_sent() ) {
+		if ( headers_sent() || session_status() === PHP_SESSION_ACTIVE ) {
 			return;
 		}
 


### PR DESCRIPTION
If a different plugin starts the session before this one, then this one emits a PHP warning at line 143:  Warning: ini_set(): A session is active. You cannot change the session module's ini settings at this time in.  Adding a check for `session_status() === PHP_SESSION_ACTIVE` prevents this warning by avoiding a change to the session's behavior while the session exists.  This is an alternative to running this plugin as an `mu-plugin` as is suggested in [this issue](https://github.com/pantheon-systems/wp-native-php-sessions/issues/84).