### PR TITLE
Add bypass for WP-CLI in Pantheon_Sessions->load()

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -47,6 +47,10 @@ class Pantheon_Sessions {
 	 */
 	private function load() {
 
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return;
+		}
+
 		if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 			return;
 		}


### PR DESCRIPTION
This to eliminate `Cannot change save handler when headers already sent` being written to the error log.