### PR TITLE
Revert "Avoid initializing PHP sessions when running WP-CLI"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** comments, sessions  
 **Requires at least:** 4.7  
 **Tested up to:** 5.4  
-**Stable tag:** 1.1.1  
+**Stable tag:** 1.1.0  
 **Requires PHP:** 5.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -66,9 +66,6 @@ However, if you intend to scale your application, local tempfiles are a dangerou
 
 
 ## Changelog ##
-
-### 1.1.1 (May 11th, 2020) ###
-* Avoid initializing PHP sessions when running WP-CLI [[#151](https://github.com/pantheon-systems/wp-native-php-sessions/pull/151)].
 
 ### 1.1.0 (April 23rd, 2020) ###
 * Avoids initializing PHP sessions when doing cron [[#149](https://github.com/pantheon-systems/wp-native-php-sessions/pull/149)].

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Native PHP Sessions for WordPress
- * Version: 1.1.1
+ * Version: 1.1.0
  * Description: Offload PHP's native sessions to your database for multi-server compatibility.
  * Author: Pantheon
  * Author URI: https://www.pantheon.io/
@@ -14,7 +14,7 @@
 
 use Pantheon_Sessions\Session;
 
-define( 'PANTHEON_SESSIONS_VERSION', '1.1.1' );
+define( 'PANTHEON_SESSIONS_VERSION', '1.1.0' );
 
 /**
  * Main controller class for the plugin.
@@ -52,10 +52,6 @@ class Pantheon_Sessions {
 		}
 
 		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
-			return;
-		}
-
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andr
 Tags: comments, sessions
 Requires at least: 4.7
 Tested up to: 5.4
-Stable tag: 1.1.1
+Stable tag: 1.1.0
 Requires PHP: 5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -66,9 +66,6 @@ If you see an error like "Fatal error: session_start(): Failed to initialize sto
 
 
 == Changelog ==
-
-= 1.1.1 (May 11th, 2020) =
-* Avoid initializing PHP sessions when running WP-CLI [[#151](https://github.com/pantheon-systems/wp-native-php-sessions/pull/151)].
 
 = 1.1.0 (April 23rd, 2020) =
 * Avoids initializing PHP sessions when doing cron [[#149](https://github.com/pantheon-systems/wp-native-php-sessions/pull/149)].


### PR DESCRIPTION
Reverts pantheon-systems/wp-native-php-sessions#151