### PR TITLE
Domain Path removed

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -7,7 +7,6 @@
  * Author URI: https://www.pantheon.io/
  * Plugin URI: https://wordpress.org/plugins/wp-native-php-sessions/
  * Text Domain: pantheon-sessions
- * Domain Path: /languages
  *
  * @package WPNPS
  **/


### PR DESCRIPTION
The translations are currently not pulled through wordpress.org, so I removed the Domain Path.