### PR TITLE
Support external database

### DIFF
--- a/inc/class-cli-command.php
+++ b/inc/class-cli-command.php
@@ -23,7 +23,8 @@ class CLI_Command extends \WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_( $args, $assoc_args ) {
-		global $wpdb;
+		global $sessiondb;
+		$sessiondb = \Pantheon_Sessions\Session::connect_to_session_db();
 
 		if ( ! PANTHEON_SESSIONS_ENABLED ) {
 			WP_CLI::error( 'Pantheon Sessions is currently disabled.' );
@@ -36,7 +37,7 @@ class CLI_Command extends \WP_CLI_Command {
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
 		$sessions = array();
-		foreach ( new \WP_CLI\Iterators\Query( "SELECT * FROM {$wpdb->pantheon_sessions} ORDER BY datetime DESC" ) as $row ) {
+		foreach ( new \WP_CLI\Iterators\Query( "SELECT * FROM {$sessiondb->pantheon_sessions} ORDER BY datetime DESC" ) as $row ) {
 			$sessions[] = $row;
 		}
 
@@ -56,14 +57,15 @@ class CLI_Command extends \WP_CLI_Command {
 	 * @subcommand delete
 	 */
 	public function delete( $args, $assoc_args ) {
-		global $wpdb;
+		global $sessiondb;
+		$sessiondb = \Pantheon_Sessions\Session::connect_to_session_db();
 
 		if ( ! PANTHEON_SESSIONS_ENABLED ) {
 			WP_CLI::error( 'Pantheon Sessions is currently disabled.' );
 		}
 
 		if ( isset( $assoc_args['all'] ) ) {
-			$args = $wpdb->get_col( "SELECT session_id FROM {$wpdb->pantheon_sessions}" );
+			$args = $sessiondb->get_col( "SELECT session_id FROM {$sessiondb->pantheon_sessions}" );
 			if ( empty( $args ) ) {
 				WP_CLI::warning( 'No sessions to delete.' );
 			}

--- a/inc/class-list-table.php
+++ b/inc/class-list-table.php
@@ -16,7 +16,8 @@ class List_Table extends \WP_List_Table {
 	 * Prepare the items for the list table
 	 */
 	public function prepare_items() {
-		global $wpdb;
+		global $sessiondb;
+		$sessiondb = Session::connect_to_session_db();
 
 		$columns               = $this->get_columns();
 		$hidden                = array();
@@ -27,8 +28,8 @@ class List_Table extends \WP_List_Table {
 		$paged    = ( isset( $_GET['paged'] ) ) ? (int) $_GET['paged'] : 1;
 		$offset   = $per_page * ( $paged - 1 );
 
-		$this->items = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->pantheon_sessions ORDER BY datetime DESC LIMIT %d,%d", $offset, $per_page ) );
-		$total_items = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pantheon_sessions" );
+		$this->items = $sessiondb->get_results( $sessiondb->prepare( "SELECT * FROM $sessiondb->pantheon_sessions ORDER BY datetime DESC LIMIT %d,%d", $offset, $per_page ) );
+		$total_items = $sessiondb->get_var( "SELECT COUNT(*) FROM $sessiondb->pantheon_sessions" );
 
 		$this->set_pagination_args(
 			array(
@@ -67,7 +68,7 @@ class List_Table extends \WP_List_Table {
 	 */
 	public function column_default( $item, $column_name ) {
 		if ( 'data' === $column_name ) {
-			return '<code>' . esc_html( $item->data ) . '</code>';
+			return '<code style="max-height: 100px;display: block;overflow: auto;">' . esc_html( $item->data ) . '</code>';
 		} elseif ( 'session_id' === $column_name ) {
 			$query_args = array(
 				'action'  => 'pantheon_clear_session',

--- a/inc/class-session-handler.php
+++ b/inc/class-session-handler.php
@@ -40,14 +40,12 @@ class Session_Handler implements \SessionHandlerInterface {
 		if ( ! $session ) {
 			$session = Session::create_for_sid( $session_id );
 		}
-
 		if ( ! $session ) {
 			trigger_error( 'Could not write session to the database. Please check MySQL configuration.', E_USER_WARNING );
 			return false;
 		}
 
 		$session->set_data( $session_data );
-
 		return true;
 	}
 
@@ -96,16 +94,15 @@ class Session_Handler implements \SessionHandlerInterface {
 	 * @param integer $maxlifetime Maximum lifetime in seconds.
 	 */
 	public function gc( $maxlifetime ) {
-		global $wpdb;
-
-		$wpdb = Session::restore_wpdb_if_null( $wpdb );
+		global $sessiondb;
+		$sessiondb = Session::connect_to_session_db();
 
 		// Be sure to adjust 'php_value session.gc_maxlifetime' to a large enough
 		// value. For example, if you want user sessions to stay in your database
 		// for three weeks before deleting them, you need to set gc_maxlifetime
 		// to '1814400'. At that value, only after a user doesn't log in after
 		// three weeks (1814400 seconds) will his/her session be removed.
-		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->pantheon_sessions WHERE `datetime` <= %s ", gmdate( 'Y-m-d H:i:s', time() - $maxlifetime ) ) );
+		$sessiondb->query( $sessiondb->prepare( "DELETE FROM $sessiondb->pantheon_sessions WHERE `datetime` <= %s ", gmdate( 'Y-m-d H:i:s', time() - $maxlifetime ) ) );
 		return true;
 	}
 

--- a/tests/phpunit/test-init-plugin.php
+++ b/tests/phpunit/test-init-plugin.php
@@ -21,13 +21,13 @@ class Test_Init_Plugin extends WP_UnitTestCase {
 	 * Ensures the database is created when the test suite runs.
 	 */
 	public function test_database_created() {
-		global $wpdb, $table_prefix;
+		global $sessiondb, $table_prefix;
 
 		$table_name = "{$table_prefix}pantheon_sessions";
-		$this->assertEquals( $table_name, $wpdb->pantheon_sessions );
+		$this->assertEquals( $table_name, $sessiondb->pantheon_sessions );
 
 		// phpcs:ignore
-		$column_data = $wpdb->get_results( "SHOW COLUMNS FROM {$table_name}" );
+		$column_data = $sessiondb->get_results( "SHOW COLUMNS FROM {$table_name}" );
 		$columns     = wp_list_pluck( $column_data, 'Field' );
 		$this->assertEquals(
 			array(

--- a/tests/phpunit/test-sessions.php
+++ b/tests/phpunit/test-sessions.php
@@ -37,12 +37,12 @@ class Test_Sessions extends WP_UnitTestCase {
 	 * Sets up the test suite prior to every test.
 	 */
 	public function setUp() {
-		global $wpdb;
+		global $sessiondb;
 		if ( ! isset( $this->table_name ) ) {
-			$this->table_name = $wpdb->pantheon_sessions;
+			$this->table_name = $sessiondb->pantheon_sessions;
 		}
-		$wpdb->pantheon_sessions = $this->table_name;
-		$this->suppress_errors   = $wpdb->suppress_errors();
+		$sessiondb->pantheon_sessions = $this->table_name;
+		$this->suppress_errors   = $sessiondb->suppress_errors();
 		if ( ! Session::get_by_sid( session_id() ) ) {
 			Session::create_for_sid( session_id() );
 		}
@@ -83,11 +83,11 @@ class Test_Sessions extends WP_UnitTestCase {
 	public function test_session_write_error() {
 		$this->markTestSkipped( 'Fails to trigger warning when entire suite is run.' );
 
-		global $wpdb;
+		global $sessiondb;
 		// Set an invalid table to fail queries.
-		$backup_table            = $wpdb->pantheon_sessions;
-		$wpdb->pantheon_sessions = 'foobar1235';
-		$wpdb->suppress_errors( true );
+		$backup_table            = $sessiondb->pantheon_sessions;
+		$sessiondb->pantheon_sessions = 'foobar1235';
+		$sessiondb->suppress_errors( true );
 		$_SESSION['foo'] = 'bar';
 		session_commit();
 		// Error is triggered.
@@ -131,17 +131,17 @@ class Test_Sessions extends WP_UnitTestCase {
 	public function test_session_garbage_collection() {
 		$this->markTestSkipped( 'ini_set() never works once headers have been set' );
 
-		global $wpdb;
+		global $sessiondb;
 		$_SESSION['foo'] = 'bar';
 		session_commit();
-		$this->assertEquals( 1, $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pantheon_sessions" ) );
+		$this->assertEquals( 1, $sessiondb->get_var( "SELECT COUNT(*) FROM $sessiondb->pantheon_sessions" ) );
 		$current_val = ini_get( 'session.gc_maxlifetime' );
 		ini_set( 'session.gc_maxlifetime', 100000000 );
 		_pantheon_session_garbage_collection( ini_get( 'session.gc_maxlifetime' ) );
-		$this->assertEquals( 1, $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pantheon_sessions" ) );
+		$this->assertEquals( 1, $sessiondb->get_var( "SELECT COUNT(*) FROM $sessiondb->pantheon_sessions" ) );
 		ini_set( 'session.gc_maxlifetime', 0 );
 		_pantheon_session_garbage_collection( ini_get( 'session.gc_maxlifetime' ) );
-		$this->assertEquals( 0, $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->pantheon_sessions" ) );
+		$this->assertEquals( 0, $sessiondb->get_var( "SELECT COUNT(*) FROM $sessiondb->pantheon_sessions" ) );
 		ini_set( 'session.gc_maxlifetime', $current_val );
 	}
 
@@ -176,10 +176,10 @@ class Test_Sessions extends WP_UnitTestCase {
 	 * Runs at the end of every test.
 	 */
 	public function tearDown() {
-		global $wpdb;
-		$wpdb->pantheon_sessions = $this->table_name;
-		$wpdb->suppress_errors( $this->suppress_errors );
-		$results = $wpdb->query( "DELETE FROM {$wpdb->pantheon_sessions}" );
+		global $sessiondb;
+		$sessiondb->pantheon_sessions = $this->table_name;
+		$sessiondb->suppress_errors( $this->suppress_errors );
+		$results = $sessiondb->query( "DELETE FROM {$sessiondb->pantheon_sessions}" );
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
Added support to connect to an external database so that sessions can be offloaded outside the main wordpress database if needed.

The following code can be added to wp-config.php tp override the default behavior.  If the custom parameters are not defined the plugin will continue to use the default wordpress database.

/** The name of the database for Sessions */
define('SESSION_DB_NAME', 'sessions_db');
/** Sessions MySQL database username */
define('SESSION_DB_USER', 'root');
/** Sessions MySQL database password */
define('SESSION_DB_PASSWORD', '');
/** Sessions MySQL hostname */
define('SESSION_DB_HOST', 'localhost');