### PR TITLE
Prepare for 1.2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WordPress Native PHP Sessions #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [outlandish josh](https://profiles.wordpress.org/outlandish josh), [mpvanwinkle77](https://profiles.wordpress.org/mpvanwinkle77), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [andrew.taylor](https://profiles.wordpress.org/andrew.taylor)  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [outlandish josh](https://profiles.wordpress.org/outlandish-josh), [mpvanwinkle77](https://profiles.wordpress.org/mpvanwinkle77), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [andrew.taylor](https://profiles.wordpress.org/andrew.taylor), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence), [stovak](https://github.com/stovak)  
 **Tags:** comments, sessions  
 **Requires at least:** 4.7  
 **Tested up to:** 6.1  

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use native PHP sessions and stay horizontally scalable. Better living through su
 ## Description ##
 
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained-support)
-[![Build Status](https://travis-ci.org/pantheon-systems/wp-native-php-sessions.svg?branch=master)](https://travis-ci.org/pantheon-systems/wp-native-php-sessions) [![CircleCI](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/master.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/master)
+ [![CircleCI](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/master.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/master)
 
 WordPress core does not use PHP sessions, but sometimes they are required by your use-case, a plugin or theme.
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ This mu-plugin will load WP Native PHP Sessions before all other plugins, while 
 
 ## Changelog ##
 
+### 1.2.5 (October 28th, 2022) ###
+* Added `#[ReturnTypeWillChange]` where required to silence deprecation warnings in PHP 8.1. [[#216](https://github.com/pantheon-systems/wp-native-php-sessions/pull/216)]
+
 ### 1.2.4 (September 14th, 2021) ###
 * Increases data blob size from 64k to 16M for new session tables; existing tables will need to manually modify the column if they want to apply this change [[#193](https://github.com/pantheon-systems/wp-native-php-sessions/pull/193)].
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [outlandish josh](https://profiles.wordpress.org/outlandish josh), [mpvanwinkle77](https://profiles.wordpress.org/mpvanwinkle77), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [andrew.taylor](https://profiles.wordpress.org/andrew.taylor)  
 **Tags:** comments, sessions  
 **Requires at least:** 4.7  
-**Tested up to:** 5.9  
-**Stable tag:** 1.2.4  
+**Tested up to:** 6.1  
+**Stable tag:** 1.2.5  
 **Requires PHP:** 5.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Native PHP Sessions for WordPress
- * Version: 1.2.4
+ * Version: 1.2.5
  * Description: Offload PHP's native sessions to your database for multi-server compatibility.
  * Author: Pantheon
  * Author URI: https://www.pantheon.io/
@@ -13,7 +13,7 @@
 
 use Pantheon_Sessions\Session;
 
-define( 'PANTHEON_SESSIONS_VERSION', '1.2.4' );
+define( 'PANTHEON_SESSIONS_VERSION', '1.2.5' );
 
 /**
  * Main controller class for the plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andrew.taylor
 Tags: comments, sessions
 Requires at least: 4.7
-Tested up to: 5.9
-Stable tag: 1.2.4
+Tested up to: 6.1
+Stable tag: 1.2.5
 Requires PHP: 5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WordPress Native PHP Sessions ===
-Contributors: getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andrew.taylor
+Contributors: getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andrew.taylor, jazzs3quence
 Tags: comments, sessions
 Requires at least: 4.7
 Tested up to: 6.1

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,9 @@ This mu-plugin will load WP Native PHP Sessions before all other plugins, while 
 
 == Changelog ==
 
+= 1.2.5 (October 28, 2022) =
+* Added `#[ReturnTypeWillChange]` where required to silence deprecation warnings in PHP 8.1. [[#216](https://github.com/pantheon-systems/wp-native-php-sessions/pull/216)]
+
 = 1.2.4 (September 14th, 2021) =
 * Increases data blob size from 64k to 16M for new session tables; existing tables will need to manually modify the column if they want to apply this change [[#193](https://github.com/pantheon-systems/wp-native-php-sessions/pull/193)].
 
@@ -141,11 +144,11 @@ This mu-plugin will load WP Native PHP Sessions before all other plugins, while 
 * Compatibility with PHP 7.
 * Adds `pantheon_session_expiration` filter to modify session expiration value.
 
-= 0.4 = 
+= 0.4 =
 * Adjustment to `session_id()` behavior for wider compatibility
 * Using superglobal for REQUEST_TIME as opposed to `time()`
 
-= 0.3 = 
+= 0.3 =
 * Fixes issue related to WordPress plugin load order
 
 = 0.1 =


### PR DESCRIPTION
Bumps version & tested up to, updates changelog & contributors list, removes unused build status.