### PR TITLE
[CMSP-79] Add #[\ReturnTypeWillChange] attribute for php 8

### DIFF
--- a/inc/class-session-handler.php
+++ b/inc/class-session-handler.php
@@ -119,6 +119,7 @@ class Session_Handler implements \SessionHandlerInterface {
 	 *
 	 * @return boolean
 	 */
+	#[\ReturnTypeWillChange]
 	public function close() {
 		return true;
 	}


### PR DESCRIPTION
With php 8, we're seeing this notice:

`Deprecated: Return type of Pantheon_Sessions\Session_Handler::close() should either be compatible with SessionHandlerInterface::close(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in wp-content/plugins/wp-native-php-sessions/inc/class-session-handler.php on line 122`

This patch adds the same fix to the close() method that was already added to the others in 042c9be24df5d6a7ec27a9253cbd9dc685105913

Fixes #230