### PR TITLE
Release 1.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This mu-plugin will load WP Native PHP Sessions before all other plugins, while 
 ## Changelog ##
 
 ### 1.3.3 (January 25, 2023) ###
-* Bump version in pantheon-sessions.php [[#233](https://github.com/pantheon-systems/wp-native-php-sessions/pull/233)].
+* Bump version in pantheon-sessions.php [[#234](https://github.com/pantheon-systems/wp-native-php-sessions/pull/234)].
 
 ### 1.3.2 (January 25, 2023) ###
 * PHP 8.2 compatibility [[#232](https://github.com/pantheon-systems/wp-native-php-sessions/pull/232)].

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** comments, sessions  
 **Requires at least:** 4.7  
 **Tested up to:** 6.1  
-**Stable tag:** 1.3.2  
+**Stable tag:** 1.3.3  
 **Requires PHP:** 5.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -70,6 +70,9 @@ To fix, create a new file at `wp-content/mu-plugins/000-loader.php` and include 
 This mu-plugin will load WP Native PHP Sessions before all other plugins, while letting you still use the WordPress plugin updater to keep the plugin up-to-date.
 
 ## Changelog ##
+
+### 1.3.3 (January 25, 2023) ###
+* Bump version in pantheon-sessions.php [[#233](https://github.com/pantheon-systems/wp-native-php-sessions/pull/233)].
 
 ### 1.3.2 (January 25, 2023) ###
 * PHP 8.2 compatibility [[#232](https://github.com/pantheon-systems/wp-native-php-sessions/pull/232)].

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-native-php-sessions",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-native-php-sessions",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/pantheon-systems/wp-native-php-sessions.git"

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Native PHP Sessions for WordPress
- * Version: 1.3.1
+ * Version: 1.3.3
  * Description: Offload PHP's native sessions to your database for multi-server compatibility.
  * Author: Pantheon
  * Author URI: https://www.pantheon.io/
@@ -13,7 +13,7 @@
 
 use Pantheon_Sessions\Session;
 
-define( 'PANTHEON_SESSIONS_VERSION', '1.3.2' );
+define( 'PANTHEON_SESSIONS_VERSION', '1.3.3' );
 
 /**
  * Main controller class for the plugin.

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ This mu-plugin will load WP Native PHP Sessions before all other plugins, while 
 == Changelog ==
 
 = 1.3.3 (January 25, 2023) =
-* Bump version in pantheon-sessions.php [[#233](https://github.com/pantheon-systems/wp-native-php-sessions/pull/233)].
+* Bump version in pantheon-sessions.php [[#234](https://github.com/pantheon-systems/wp-native-php-sessions/pull/234)].
 
 = 1.3.2 (January 25, 2023) =
 * PHP 8.2 compatibility [[#232](https://github.com/pantheon-systems/wp-native-php-sessions/pull/232)].

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andr
 Tags: comments, sessions
 Requires at least: 4.7
 Tested up to: 6.1
-Stable tag: 1.3.2
+Stable tag: 1.3.3
 Requires PHP: 5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -69,6 +69,9 @@ To fix, create a new file at `wp-content/mu-plugins/000-loader.php` and include 
 This mu-plugin will load WP Native PHP Sessions before all other plugins, while letting you still use the WordPress plugin updater to keep the plugin up-to-date.
 
 == Changelog ==
+
+= 1.3.3 (January 25, 2023) =
+* Bump version in pantheon-sessions.php [[#233](https://github.com/pantheon-systems/wp-native-php-sessions/pull/233)].
 
 = 1.3.2 (January 25, 2023) =
 * PHP 8.2 compatibility [[#232](https://github.com/pantheon-systems/wp-native-php-sessions/pull/232)].


### PR DESCRIPTION
Missed bumping the version in [one location](https://github.com/pantheon-systems/wp-native-php-sessions/blob/main/pantheon-sessions.php#L4) for 1.3.2 🤦 so creating 1.3.3 to address.