### PR TITLE
Update compsoser.json with fixed license version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pantheon-systems/wp-native-php-sessions",
     "description": "native PHP sessions stored in the database for WordPress.",
     "type": "wordpress-plugin",
-    "license": "GPLv2 or later",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Pantheon",


### PR DESCRIPTION
Some packagist builds are failing because of `composer.json` linting issues from the way the license was written in our `composer.json`. This update fixes it to [spdx.org](https://spdx.org/licenses/) standards.