### PR TITLE
[BUGS-5809] Add fallback for $session->get_data()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pantheon-systems/wp-native-php-sessions",
     "description": "native PHP sessions stored in the database for WordPress.",
     "type": "wordpress-plugin",
-    "license": "GPLv2 or later",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Pantheon",

--- a/inc/class-session-handler.php
+++ b/inc/class-session-handler.php
@@ -71,7 +71,7 @@ class Session_Handler implements \SessionHandlerInterface {
 
 		$session = Session::get_by_sid( $session_id );
 		if ( $session ) {
-			return $session->get_data();
+			return $session->get_data() ?: '';
 		} else {
 			return '';
 		}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,4 +33,10 @@
 	<rule ref="Squiz.Commenting.FunctionComment.MissingParamTag">
 		<exclude-pattern>*/inc/class-cli-command.php</exclude-pattern>
 	</rule>
+
+  <!-- Excluded sniffs -->
+  <rule ref="Universal.Operators.DisallowShortTernary.Found">
+    <exclude-pattern>*/inc/*</exclude-pattern>
+    <exclude-pattern>pantheon-sessions.php</exclude-pattern>
+  </rule>
 </ruleset>


### PR DESCRIPTION
Reported in https://wordpress.org/support/topic/php-warning-session_start-failed-to-read-session-data-user/

If `$session` has some data, but `get_data()` method returns null, a PHP warning will appear in the error logs. User reported that they suspect it's when a session is opened but the user was not authorized.