### PR TITLE
Enhance informational Error message for the case of headers already sent

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -164,7 +164,21 @@ class Pantheon_Sessions {
 		require_once __DIR__ . '/inc/class-session-handler.php';
 		$session_handler = new Pantheon_Sessions\Session_Handler();
 		if ( PHP_SESSION_ACTIVE !== session_status() ) {
-			session_set_save_handler( $session_handler, false );
+			// Check if headers have already been sent
+			if ( headers_sent( $file, $line ) ) {
+				// Output a friendly error message if headers are already sent
+				trigger_error(
+					sprintf(
+						/* translators: %1s: File path, %2d: Line number */
+						__("Oops! The wp-native-php-sessions plugin couldn't start the session because output has already been sent. This might be caused by PHP throwing errors. Please check the code in %1s on line %2d."),
+						$file,
+						$line
+					),
+					E_USER_WARNING
+				);
+			} else {
+				session_set_save_handler($session_handler, false);
+			}
 		}
 		// Close the session before $wpdb destructs itself.
 		add_action( 'shutdown', 'session_write_close', 999, 0 );


### PR DESCRIPTION
This code update enhances the error message displayed by the plugin when it is unable to perform its intended functionality due to headers already being sent. The original error message was "_session_set_save_handler(): Session save handler cannot be changed after headers have already been sent_" has been transformed into a more user-friendly and informative message. The updated error message helps users understand that the plugin was unable to work properly and provides insight into the cause, such as PHP throwing errors, the case that happened for me. By improving the error message, users can better troubleshoot and resolve the issue instead of thinking that wp-native-php-sessions plugin falied.