### PR TITLE
Removing PHP 8.2 deprecated dynamic property error

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -28,6 +28,13 @@ class Pantheon_Sessions {
 	private static $instance;
 
 	/**
+	 * The admin instance.
+	 *
+	 * @var \Pantheon_Sessions\Admin
+	 */
+	private $admin;
+
+	/**
 	 * Gets a copy of the singleton instance.
 	 *
 	 * @return object


### PR DESCRIPTION
This PR intends to fix this error added by PHP 8.2:

> Deprecated: Creation of dynamic property Pantheon_Sessions::$admin is deprecated in /usr/src/app/content/plugins/wp-native-php-sessions/pantheon-sessions.php on line 93