### PR TITLE
[BUGS-6317] Adds $admin property

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [outlandish josh](https://profiles.wordpress.org/outlandish-josh), [mpvanwinkle77](https://profiles.wordpress.org/mpvanwinkle77), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [andrew.taylor](https://profiles.wordpress.org/andrew.taylor), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence), [stovak](https://profiles.wordpress.org/stovak), [jspellman](https://profiles.wordpress.org/jspellman/)  
 **Tags:** comments, sessions  
 **Requires at least:** 4.7  
-**Tested up to:** 6.2  
-**Stable tag:** 1.3.5  
+**Tested up to:** 6.2.2  
+**Stable tag:** 1.3.6  
 **Requires PHP:** 5.4  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -70,6 +70,9 @@ To fix, create a new file at `wp-content/mu-plugins/000-loader.php` and include 
 This mu-plugin will load WP Native PHP Sessions before all other plugins, while letting you still use the WordPress plugin updater to keep the plugin up-to-date.
 
 ## Changelog ##
+
+### 1.3.6 (June 1, 2023) ###
+* Fixes PHP 8.2 deprecated dynamic property error [[#251](https://github.com/pantheon-systems/wp-native-php-sessions/pull/251)] (props @miguelaxcar)
 
 ### 1.3.5 (April 7, 2023) ###
 * Bump yoast/phpunit-polyfills from 1.0.4 to 1.0.5 [[#245](https://github.com/pantheon-systems/wp-native-php-sessions/pull/245)].

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -171,9 +171,9 @@ class Pantheon_Sessions {
 		require_once __DIR__ . '/inc/class-session-handler.php';
 		$session_handler = new Pantheon_Sessions\Session_Handler();
 		if ( PHP_SESSION_ACTIVE !== session_status() ) {
-			// Check if headers have already been sent
+			// Check if headers have already been sent.
 			if ( headers_sent( $file, $line ) ) {
-				// Output a friendly error message if headers are already sent
+				// Output a friendly error message if headers are already sent.
 				trigger_error(
 					sprintf(
 						/* translators: %1s: File path, %2d: Line number */

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -28,6 +28,13 @@ class Pantheon_Sessions {
 	private static $instance;
 
 	/**
+	 * The admin instance.
+	 *
+	 * @var \Pantheon_Sessions\Admin
+	 */
+	private $admin;
+
+	/**
 	 * Gets a copy of the singleton instance.
 	 *
 	 * @return object

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Native PHP Sessions for WordPress
- * Version: 1.3.5
+ * Version: 1.3.6
  * Description: Offload PHP's native sessions to your database for multi-server compatibility.
  * Author: Pantheon
  * Author URI: https://www.pantheon.io/

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andr
 Tags: comments, sessions
 Requires at least: 4.7
 Tested up to: 6.2.2
+Stable tag: 1.3.6-dev
 Requires PHP: 5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: getpantheon, outlandish josh, mpvanwinkle77, danielbachhuber, andrew.taylor, jazzs3quence, stovak, jspellman
 Tags: comments, sessions
 Requires at least: 4.7
-Tested up to: 6.2
-Stable tag: 1.3.5
+Tested up to: 6.2.2
+Stable tag: 1.3.6
 Requires PHP: 5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -69,6 +69,9 @@ To fix, create a new file at `wp-content/mu-plugins/000-loader.php` and include 
 This mu-plugin will load WP Native PHP Sessions before all other plugins, while letting you still use the WordPress plugin updater to keep the plugin up-to-date.
 
 == Changelog ==
+= 1.3.6 (June 1, 2023) =
+* Fixes PHP 8.2 deprecated dynamic property error [[#251](https://github.com/pantheon-systems/wp-native-php-sessions/pull/251)] (props @miguelaxcar)
+
 = 1.3.5 (April 7, 2023) =
 * Bump yoast/phpunit-polyfills from 1.0.4 to 1.0.5 [[#245](https://github.com/pantheon-systems/wp-native-php-sessions/pull/245)].
 * Bump tested up to version


### PR DESCRIPTION
This PR intends to fix this error added by PHP 8.2:

Deprecated: Creation of dynamic property Pantheon_Sessions::$admin is deprecated in /usr/src/app/content/plugins/wp-native-php-sessions/pantheon-sessions.php on line 93

Copied from #250 by @miguelAxcar