### PR TITLE
Update CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Use native PHP sessions and stay horizontally scalable. Better living through su
 ## Description ##
 
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained-support)
- [![CircleCI](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/master.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/master)
+ [![CircleCI](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/main.svg?style=svg)](https://circleci.com/gh/pantheon-systems/wp-native-php-sessions/tree/main)
 
 WordPress core does not use PHP sessions, but sometimes they are required by your use-case, a plugin or theme.
 


### PR DESCRIPTION
Updates the (broken) Circle badge to point to the `main` branch instead of `master`.