### PR TITLE
New Lint & Test Workflow validating README.md

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,10 @@
+name: Linting & Test
+on: [push]
+jobs:
+  validate-readme-spacing:
+    name: Validate README Spacing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: pantheon-systems/validate-readme-spacing@v1


### PR DESCRIPTION
Two trailing spaces are required for single line breaks to appear in Markdown's rendered view.
Adds github action to check for invalid spacing of the Plugin's README header.