### PR TITLE
BUGS-7030 -- fix PHP warning on add-index

### DIFF
--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -376,7 +376,13 @@ class Pantheon_Sessions {
 
 		$count_query = "SELECT COUNT(*) FROM {$table};";
 		$count_total = $wpdb->get_results( $count_query );
-		$count_total = $count_total[0]->{'COUNT(*)'};
+
+		// Avoid errors when object returns an empty object.
+		if ( ! empty( $count_total ) ) {
+			$count_total = $count_total[0]->{'COUNT(*)'};
+		} else {
+			$count_total = 0;
+		}
 
 		if ( $count_total >= 20000 ) {
 			// translators: %s is the total number of rows that exist in the pantheon_sessions table.

--- a/readme.txt
+++ b/readme.txt
@@ -105,6 +105,7 @@ Adds a WP-CLI command to add an index to the sessions table if one does not exis
 == Changelog ==
 
 = 1.4.2-dev =
+* Fixed an issue with the `pantheon session add-index` PHP warning.
 
 = 1.4.1 (October 23, 2023) =
 * Fixed an issue with the `pantheon session add-index` command not working properly on WP multisite [[#270](https://github.com/pantheon-systems/wp-native-php-sessions/pull/270)]


### PR DESCRIPTION
Would fix the error when running `wp pantheon session add-index`

”Warning: Undefined array key 0 in /code/wp-content/plugins/wp-native-php-sessions/pantheon-sessions.php on line 379