### PR TITLE
CLI command missing space

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Adds a WP-CLI command to add an index to the sessions table if one does not exis
 
 ### 1.4.2-dev ###
 * Fixed an issue with the `pantheon session add-index` PHP warning. [[#276](https://github.com/pantheon-systems/wp-native-php-sessions/pull/276/files)]
+* Fixed a syntax issue with the suggested WP CLI commands [[#278](https://github.com/pantheon-systems/wp-native-php-sessions/pull/278)]
 
 ### 1.4.1 (October 23, 2023) ###
 * Fixed an issue with the `pantheon session add-index` command not working properly on WP multisite [[#270](https://github.com/pantheon-systems/wp-native-php-sessions/pull/270)]

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -289,7 +289,7 @@ class Pantheon_Sessions {
 		$old_table = $wpdb->prefix . 'bak_pantheon_sessions';
 		$query = "SHOW KEYS FROM {$table_name} WHERE key_name = 'PRIMARY';";
 		$is_pantheon = isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ? true : false;
-		$wp_cli_cmd = $is_pantheon ? 'terminus wp &lt;site&gt;.&lt;env&gt; --' : 'wp';
+		$wp_cli_cmd = $is_pantheon ? 'terminus wp &lt;site&gt;.&lt;env&gt; -- ' : 'wp ';
 		$cli_add_index = $wp_cli_cmd . 'pantheon session add-index';
 		$key_existence = $wpdb->get_results( $query );
 		$user_id = get_current_user_id();

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,7 @@ Adds a WP-CLI command to add an index to the sessions table if one does not exis
 
 = 1.4.2-dev =
 * Fixed an issue with the `pantheon session add-index` PHP warning. [[#276](https://github.com/pantheon-systems/wp-native-php-sessions/pull/276/files)]
+* Fixed a syntax issue with the suggested WP CLI commands [[#278](https://github.com/pantheon-systems/wp-native-php-sessions/pull/278)]
 
 = 1.4.1 (October 23, 2023) =
 * Fixed an issue with the `pantheon session add-index` command not working properly on WP multisite [[#270](https://github.com/pantheon-systems/wp-native-php-sessions/pull/270)]


### PR DESCRIPTION
Resulted in malformed command suggestions like:

`terminus wp <site>.<env> --pantheon session add-index`

And
`wppantheon session add-index`

Adding a space corrects this.