### PR TITLE
[BUGS-7105] check if the `$output` index is set before manipulating it

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Adds a WP-CLI command to add an index to the sessions table if one does not exis
 ## Changelog ##
 
 ### 1.4.3-dev ###
+* Fixed a PHP warning when running the `pantheon session add-index` command on a single site installation. [[#285](https://github.com/pantheon-systems/wp-native-php-sessions/pull/285)]
 
 ### 1.4.2 (November 8, 2023) ###
 * Fixed an issue with the `pantheon session add-index` PHP warning. [[#276](https://github.com/pantheon-systems/wp-native-php-sessions/pull/276/files)]

--- a/pantheon-sessions.php
+++ b/pantheon-sessions.php
@@ -539,7 +539,7 @@ class Pantheon_Sessions {
 		$query = $wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table ) );
 		if ( ! $wpdb->get_var( $query ) == $table ) {
 			$this->safe_output( __( 'This site does not have a pantheon_sessions table, and is being skipped.', 'wp-native-php-sessions' ), 'log' );
-			$output['no_session_table'] = $output['no_session_table'] + 1;
+			$output['no_session_table'] = isset( $output['no_session_table'] ) ? $output['no_session_table'] + 1 : 1;
 
 			return $output;
 		}
@@ -559,7 +559,7 @@ class Pantheon_Sessions {
 				$type = 'log';
 			}
 
-			$output['id_column_exists'] = $output['id_column_exists'] + 1;
+			$output['id_column_exists'] = isset( $output['id_column_exists'] ) ? $output['id_column_exists'] + 1 : 1;
 			$this->safe_output( __( 'ID column already exists and does not need to be added to the table.', 'wp-native-php-sessions' ), $type );
 
 			return $output;
@@ -643,7 +643,7 @@ FROM %s ORDER BY user_id LIMIT %d OFFSET %d", $table, $batch_size, $offset );
 			if ( ! $multisite ) {
 				$type = 'error';
 			} else {
-				$output['no_old_table'] = $output['no_old_table'] + 1;
+				$output['no_old_table'] = isset( $output['no_old_table'] ) ? $output['no_old_table'] + 1 : 1;
 				$type = 'log';
 			}
 
@@ -688,7 +688,7 @@ FROM %s ORDER BY user_id LIMIT %d OFFSET %d", $table, $batch_size, $offset );
 
 		if ( ! $wpdb->get_var( $query ) == $old_clone_table ) {
 			$this->safe_output( __( 'There is no old table to roll back to.', 'wp-native-php-sessions' ), $type );
-			$output['no_rollback_table'] = $output['no_rollback_table'] + 1;
+			$output['no_rollback_table'] = isset( $output['no_rollback_table'] ) ? $output['no_rollback_table'] + 1 : 1;
 
 			return $output;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,7 @@ Adds a WP-CLI command to add an index to the sessions table if one does not exis
 == Changelog ==
 
 = 1.4.3-dev =
+* Fixed a PHP warning when running the `pantheon session add-index` command on a single site installation. [[#285](https://github.com/pantheon-systems/wp-native-php-sessions/pull/285)]
 
 = 1.4.2 (November 8, 2023) =
 * Fixed an issue with the `pantheon session add-index` PHP warning. [[#276](https://github.com/pantheon-systems/wp-native-php-sessions/pull/276/files)]


### PR DESCRIPTION
This PR fixes #284 by ensuring that any `$output` indices exist before manipulating them (in the pattern `$output['some_index'] + 1`) which returns a PHP warning if that index does not exist.