### PR TITLE
Add svn to deploy workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,11 @@ updates:
     day: tuesday
   target-branch: "develop"
   open-pull-requests-limit: 99
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    timezone: America/Los_Angeles
+    day: tuesday
+  target-branch: "develop"
+  open-pull-requests-limit: 99

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -7,7 +7,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: Install Subversion
+      run: | 
+        sudo apt-get update
+        sudo apt-get install subversion
+        svn --version    
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@2.1.1
       env:


### PR DESCRIPTION
`svn` is no longer installed on GHA containers by default, we need to make sure to install it whenever we're using SVN. 
This was already addressed for our unit tests in #312 but we also need it for the 10up deploy workflow.