### PR TITLE
ci: [SITE-5205] Add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: pantheon-systems/phpcompatibility-action@bd72eb001d4fb9817c9d6e1a157a71e287f3ff80 # dev 2023-10-04T16:54:18Z
         with:
           paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/inc/*.php
-          test-versions: 7.4-
+          test-versions: 8.3-
   wporg-validation:
     name: WP.org Plugin Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: pantheon-systems/phpcompatibility-action@bd72eb001d4fb9817c9d6e1a157a71e287f3ff80 # dev 2023-10-04T16:54:18Z
         with:
           paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/inc/*.php
-          test-versions: 8.3-
+          test-versions: 7.4-
   wporg-validation:
     name: WP.org Plugin Validation
     runs-on: ubuntu-latest
@@ -69,7 +69,7 @@ jobs:
         image: mariadb:10.6
     strategy:
       matrix:
-        php_version: [7.4, 8.2, 8.3, 8.4]
+        php_version: [7.4, 8.2, 8.3, 8.4, 8.5]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup PHP


### PR DESCRIPTION
## Summary

- Add PHP 8.5 to the PHPUnit test matrix

## Context

[SITE-5205](https://getpantheon.atlassian.net/browse/SITE-5205)

PHP 8.5 compatibility verification for wp-native-php-sessions. Local PHPCompatibility scan and PHP 8.5 lint showed zero issues in plugin source code.

## Test plan

- [x] CI passes on all PHP versions in matrix (7.4, 8.2, 8.3, 8.4, 8.5)
- [x] PHPCompatibility check passes

[SITE-5205]: https://getpantheon.atlassian.net/browse/SITE-5205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ