### PR TITLE
ci: Preserve test environment on behat failure

### DIFF
--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -100,6 +100,6 @@ jobs:
       - name: Behat tests (strict)
         run: ./bin/behat-test.sh --strict
 
-      - name: Cleanup (always)
-        if: always()
+      - name: Cleanup (on success only)
+        if: success()
         run: ./bin/behat-cleanup.sh


### PR DESCRIPTION
## Summary

- Change behat cleanup step from `always()` to `success()` so the multidev environment is preserved when tests fail

## Context

When behat tests fail, the multidev is immediately deleted, making it impossible to debug the failure on the live environment. This change keeps the environment available for investigation.

Multidevs are still cleaned up on successful runs.

## Test plan

- [ ] On test success: multidev is deleted as before
- [ ] On test failure: multidev is preserved for debugging