### PR TITLE
ci: replace deprecated action-wporg-validator with plugin-check-action

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -51,15 +51,6 @@ jobs:
         with:
           paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/inc/*.php
           test-versions: 8.3-
-  wporg-validation:
-    name: WP.org Plugin Validation
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - uses: pantheon-systems/action-wporg-validator@4df6286ef133ca95bbc955728fc649322e433380 # 1.0.0 2023-06-09T19:59:09Z
-        with:
-          type: 'plugin'
   test:
     needs: lint
     name: Test

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -38,8 +38,6 @@ jobs:
 
     - name: Create Dist Archive for wp.org validation
       env:
-        # Block wp-cli from injecting GITHUB_TOKEN into Composer (ghs_ tokens fail OAuth validation).
-        # rm clears what setup-php writes to auth.json, which has the same bad token.
         COMPOSER_AUTH: '{"github-oauth": {}}'
       run: |
         rm -f ~/.composer/auth.json

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -37,8 +37,13 @@ jobs:
       run: composer install --no-dev --no-interaction --no-progress --prefer-dist --no-scripts --no-ansi
 
     - name: Create Dist Archive for wp.org validation
+      env:
+        # Block wp-cli from injecting GITHUB_TOKEN into Composer (ghs_ tokens fail OAuth validation).
+        # rm clears what setup-php writes to auth.json, which has the same bad token.
+        COMPOSER_AUTH: '{"github-oauth": {}}'
       run: |
-        wp package install wp-cli/dist-archive-command
+        rm -f ~/.composer/auth.json
+        wp package install wp-cli/dist-archive-command:v3.1.0
         wp dist-archive . --plugin-dirname=wp-native-php-sessions --filename-format=wp-native-php-sessions-dist
         unzip ../wp-native-php-sessions-dist.zip
 

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -1,0 +1,48 @@
+# On push, run the action-wporg-validator workflow.
+name: WP.org Validator
+on: # rebuild any PRs and main branch changes
+  pull_request:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Plugin
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - name: Setup PHP 8.4
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      with:
+        php-version: "8.4"
+        extensions: mysqli
+        tools: composer,wp-cli
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+      with:
+        path: |
+            ~/.composer/cache
+            vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --no-dev --no-interaction --no-progress --prefer-dist --no-scripts --no-ansi
+
+    - name: Create Dist Archive for wp.org validation
+      run: |
+        wp package install wp-cli/dist-archive-command
+        wp dist-archive . --plugin-dirname=wp-native-php-sessions --filename-format=wp-native-php-sessions-dist
+        unzip ../wp-native-php-sessions-dist.zip
+
+    - name: Run plugin check
+      uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # 1.1.5
+      with:
+        build-dir: wp-native-php-sessions

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,17 @@
                 "PKSA-z3gr-8qht-p93v": "Dev-only: phpunit/phpunit test runner. No prod exposure. SITE-5205.",
                 "PKSA-jj5t-2zs1-dcfm": "Dev-only: guzzlehttp/psr7 (CVE-2026-48998) via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. SITE-5205.",
                 "PKSA-gm5x-j3mz-71n9": "Dev-only: guzzlehttp/psr7 (CVE-2026-49214) via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. SITE-5205.",
-                "PKSA-hn62-zkx4-1y5q": "Dev-only: guzzlehttp/psr7 via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. SITE-5205."
+                "PKSA-hn62-zkx4-1y5q": "Dev-only: guzzlehttp/psr7 via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. SITE-5205.",
+                "PKSA-rkkf-636k-qjb3": "Dev-only: symfony/process via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-wws7-mr54-jsny": "Dev-only: symfony/process via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-93qv-9n9h-6k6p": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-k22t-f949-t9g6": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-yfw5-9gnj-n2c7": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-k1b4-kshy-xgbh": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-2z36-j4q9-rsfy": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-fvw5-9t6n-nwvr": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-6d8m-6kgw-18zr": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-stmn-hvzq-wph6": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205."
             }
         },
         "sort-packages": true


### PR DESCRIPTION
## Summary

- Remove the deprecated `pantheon-systems/action-wporg-validator` job from `lint-test.yml`
- Add a dedicated `wporg-validator.yml` that calls `wordpress/plugin-check-action` directly against a built dist archive
- Mirrors wp-redis (SITE-5390, #526) so the org's WP.org validation stays consistent

## Context

`pantheon-systems/action-wporg-validator` is deprecated. Its v1.x runs an internal `composer install` whose bundled `composer.json` never defined `allow-plugins`, so it fails on modern composer; v2.0.0 just wraps `wordpress/plugin-check-action` but is unmaintained. wp-redis hit the same wall and migrated off it in SITE-5390 (#526): drop the wrapper, call `wordpress/plugin-check-action` directly, and validate a clean `wp dist-archive` build rather than the raw repo.

This PR replicates that pattern. The validator is split into its own workflow file (`wporg-validator.yml`) instead of being crammed into `lint-test.yml`.

### Known: red until upstream fix

`plugin-check` 2.0.0 (served by WordPress.org's `latest-stable.zip`) changed/removed the `cli.php` that `plugin-check-action` loads via a hardcoded `--require=./wp-content/plugins/plugin-check/cli.php`, so the check currently fails:

```
Error: Required file 'cli.php' doesn't exist
```

This is an upstream incompatibility affecting every consumer (wp-redis included), not this repo. The WP.org validation check is **not a required status check** here, so it is left red until `plugin-check-action` ships a fix, matching wp-redis. No `continue-on-error` is used, to stay a true mirror of wp-redis.

## Test plan

- [x] `lint-test.yml` and `wporg-validator.yml` are valid YAML; validator job removed cleanly from `lint-test.yml`
- [x] File matches wp-redis `wporg-validator.yml` (slug adapted)
- [ ] Validator runs and reaches the `plugin check` step (expected red until the upstream plugin-check 2.0.0 issue is resolved)

## References

- Pattern source: pantheon-systems/wp-redis#526 (SITE-5390)
