### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -3,6 +3,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the wordpress-plugin-deploy workflow. Without a permissions block, the workflow runs with the default token permissions, which is broader than necessary. This resolves the CodeQL `missing-workflow-permissions` alert.

## Jira Tickets Resolved

- https://getpantheon.atlassian.net/browse/VUL-33170

## Test plan

- [ ] Verify the deploy workflow still works on release publish
- [ ] Confirm CodeQL alert is resolved
