### PR TITLE
chore(deps): [VUL-24492 et al] audit-ignore guzzle and psr7 advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
                 "PKSA-ft77-7h5f-p3r6": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5205.",
                 "PKSA-b14r-zh1d-vdrc": "Dev-only: symfony/yaml via behat test deps. No prod exposure. SITE-5205.",
                 "PKSA-z3gr-8qht-p93v": "Dev-only: phpunit/phpunit test runner. No prod exposure. SITE-5205.",
+                "PKSA-vznr-tgp9-fd7d": "Dev-only: guzzlehttp/psr7 (CVE-2026-59882) via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. VUL-24999.",
                 "PKSA-jj5t-2zs1-dcfm": "Dev-only: guzzlehttp/psr7 (CVE-2026-48998) via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. SITE-5205.",
                 "PKSA-gm5x-j3mz-71n9": "Dev-only: guzzlehttp/psr7 (CVE-2026-49214) via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. SITE-5205.",
                 "PKSA-hn62-zkx4-1y5q": "Dev-only: guzzlehttp/psr7 via fabpot/goutte behat upstream tests. Cannot upgrade (guzzle 6 pins psr7 ^1.9). No prod exposure. SITE-5205.",
@@ -65,7 +66,8 @@
                 "PKSA-2z36-j4q9-rsfy": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
                 "PKSA-fvw5-9t6n-nwvr": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
                 "PKSA-6d8m-6kgw-18zr": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
-                "PKSA-stmn-hvzq-wph6": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205."
+                "PKSA-stmn-hvzq-wph6": "Dev-only: guzzlehttp/guzzle via fabpot/goutte behat upstream tests. No prod exposure. SITE-5205.",
+                "PKSA-bcdd-5xc7-gwfb": "Dev-only: guzzlehttp/guzzle (CVE-2026-59883) via fabpot/goutte behat upstream tests. Cannot upgrade (fabpot/goutte pins guzzle ^6; patched version is 7.12.3). No prod exposure. VUL-24492."
             }
         },
         "sort-packages": true


### PR DESCRIPTION
## Summary

- Adds two `composer.audit.ignore` entries for dev-only transitive advisories with no reachable patched version
- `PKSA-bcdd-5xc7-gwfb` (CVE-2026-59883, guzzlehttp/guzzle) for VUL-24492
- `PKSA-vznr-tgp9-fd7d` (CVE-2026-59882, guzzlehttp/psr7) for VUL-24999

## Context

[VUL-24492](https://getpantheon.atlassian.net/browse/VUL-24492) | [VUL-24999](https://getpantheon.atlassian.net/browse/VUL-24999)

Both advisories affect transitive dev-only dependencies pulled in via `fabpot/goutte` (from `pantheon-systems/pantheon-wordpress-upstream-tests`, the behat upstream test suite). Neither package is in `packages` (production); `require` is empty and there are zero production packages in this repo.

Dependency chain: `pantheon-wordpress-upstream-tests` -> `fabpot/goutte v3.3.1` -> `guzzlehttp/guzzle 6.5.8` -> `guzzlehttp/psr7 1.9.1`

Upgrade is not possible without replacing the upstream test framework:

| Package | Installed | Patched In | Blocker |
|---------|-----------|------------|---------|
| guzzlehttp/guzzle | 6.5.8 | 7.12.3 | `fabpot/goutte` pins `guzzle ^6`; v7 is a major version break |
| guzzlehttp/psr7 | 1.9.1 | 2.12.3 | `guzzle 6` pins `psr7 ^1.9`; v2 is a major version break |

This follows the same pattern established in SITE-5205 for the 8 existing guzzle and 3 existing psr7 ignore entries already in `composer.json`.

Note: PR #382 (`vuln-VUL-24999`, opened by service-samwise) is also open and adds only the psr7 entry (PKSA-vznr-tgp9-fd7d). This PR supersedes it for VUL-24999 and additionally covers VUL-24492. One of the two PRs should be closed after merge to avoid a conflict.

## Release

No release needed. Both advisories are in `packages-dev` exclusively; `require` is empty and there are zero production packages. The shipped plugin artifact is unaffected. `composer audit` and `composer validate` pass on this branch.

## Test plan

- [ ] `composer audit` exits with no unignored advisories for guzzle/psr7 (12 ignored entries total shown)
- [ ] `composer validate` exits clean
- [ ] CI passes

## References

- Jira: [VUL-24492](https://getpantheon.atlassian.net/browse/VUL-24492)
- Jira: [VUL-24999](https://getpantheon.atlassian.net/browse/VUL-24999)
- Related (superseded) PR: pantheon-systems/wp-native-php-sessions#382


[VUL-24492]: https://getpantheon.atlassian.net/browse/VUL-24492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-24999]: https://getpantheon.atlassian.net/browse/VUL-24999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-24492]: https://getpantheon.atlassian.net/browse/VUL-24492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ