### PR TITLE
chore(ci): [SITE-5995] Drop stale action-wporg-validator comment

### DIFF
--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -1,4 +1,3 @@
-# On push, run the action-wporg-validator workflow.
 name: WP.org Validator
 on: # rebuild any PRs and main branch changes
   pull_request:


### PR DESCRIPTION
## Summary

- Remove the leftover `# On push, run the action-wporg-validator workflow.` comment from `.github/workflows/wporg-validator.yml`. The workflow migrated to `wordpress/plugin-check-action` and no longer uses `pantheon-systems/action-wporg-validator`.

## Context

[SITE-5995](https://getpantheon.atlassian.net/browse/SITE-5995)

Comment-only change. No workflow behavior changes.

## Test plan

- [ ] `Validate Plugin` job runs and passes on this PR

[SITE-5995]: https://getpantheon.atlassian.net/browse/SITE-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ