### PR TITLE
fix(ci): [SITE-5995] stop excluding assets from the wp.org package

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,7 +4,6 @@
 tests
 vendor
 bin
-assets
 .DS_Store
 Thumbs.db
 .editorconfig


### PR DESCRIPTION
## Summary

- Remove `assets` from `.distignore` so the WordPress.org package again includes `assets/js/notices.js`.

## Context

[SITE-5995](https://getpantheon.atlassian.net/browse/SITE-5995)

Found while auditing every plugin migrated to `plugin-check-action` for packaging regressions, after [wp-saml-auth#500](https://github.com/pantheon-systems/wp-saml-auth/pull/500) shipped a broken 2.3.3 to WordPress.org.

`10up/action-wordpress-plugin-deploy` prefers `.distignore` over `.gitattributes` whenever a `.distignore` exists ([deploy.sh#L120-L126](https://github.com/10up/action-wordpress-plugin-deploy/blob/develop/deploy.sh#L120-L126)):

```bash
if [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
	echo "ℹ︎ Using .distignore"
	rsync -rc --exclude-from="$GITHUB_WORKSPACE/.distignore" "$GITHUB_WORKSPACE/" trunk/ --delete --delete-excluded
else
	echo "ℹ︎ Using .gitattributes"
```

`.distignore` was created in #379 (`@@ -0,0 +1,22 @@`) and listed `assets`. `.gitattributes` never had an `assets export-ignore` entry, so every release to date took the `.gitattributes` path and shipped `assets/`. Adding `.distignore` silently switched the deploy to the excluding path.

`assets/js/notices.js` is loaded at runtime:

```php
// pantheon-sessions.php:93
wp_enqueue_script( 'notices', plugins_url( '/assets/js/notices.js', __FILE__ ), [ 'jquery' ], PANTHEON_SESSIONS_VERSION, true );
```

## Not yet shipped

The last release, 1.4.5, was published 2025-12-04; `.distignore` landed 2026-07-28. No release has been cut since, so no published package is affected. This fix lands before the next release rather than after it.

## Verification

Simulating the deploy rsync against the real `.distignore`, before this change:

```
trunk/inc/x.php
trunk/pantheon-sessions.php        <- assets/js/notices.js dropped
```

after:

```
trunk/assets/js/notices.js
trunk/inc/x.php
trunk/pantheon-sessions.php        <- tests/ and .distignore still excluded
```

## Notes

- No changelog entry. No released version shipped the regression, so there is nothing user-visible to describe relative to 1.4.5.
- `vendor` is left in `.distignore` deliberately: `.gitattributes` already excluded it, so it is not a change in behavior, and `composer.json` declares no runtime `require`.

## Test plan

- [ ] On the next release, confirm the deploy step logs `ℹ︎ Using .distignore` and that `assets/js/notices.js` is present in the rsync payload.
- [ ] After that release publishes, confirm the WordPress.org zip contains `assets/js/notices.js`.

## References

- Jira: [SITE-5995](https://getpantheon.atlassian.net/browse/SITE-5995)
- Same failure mode, already fixed: pantheon-systems/wp-saml-auth#500
- PR that introduced `.distignore` here: #379


[SITE-5995]: https://getpantheon.atlassian.net/browse/SITE-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5995]: https://getpantheon.atlassian.net/browse/SITE-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ