### PR TITLE
chore: group dependabot minor/patch updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     day: tuesday
   target-branch: "main"
   open-pull-requests-limit: 99
+  groups:
+    composer-minor-patch:
+      update-types:
+      - minor
+      - patch
   ignore:
   - dependency-name: phpunit/phpunit
     versions:
@@ -25,6 +30,11 @@ updates:
     day: tuesday
   target-branch: "main"
   open-pull-requests-limit: 99
+  groups:
+    npm-minor-patch:
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -33,3 +43,7 @@ updates:
     day: tuesday
   target-branch: "main"
   open-pull-requests-limit: 99
+  groups:
+    github-actions:
+      patterns:
+      - "*"


### PR DESCRIPTION
Composer and npm minor/patch updates are now grouped into a single PR per ecosystem; major version bumps still open individually. GitHub Actions updates are grouped into a single PR since action versions aren't strict semver.